### PR TITLE
added aria-label to social icon links

### DIFF
--- a/index.html
+++ b/index.html
@@ -406,13 +406,13 @@
                             <strong class="site-footer-title d-block mt-4 mb-3">Stay connected</strong>
 
                             <ul class="social-icon">
-                                <li class="social-icon-item"><a href="https://twitter.com/yesimhozman" target="blank"
+                                <li class="social-icon-item" ><a href="https://twitter.com/yesimhozman" target="blank" aria-label="Twitter"
                                         class="social-icon-link bi-twitter"></a></li>
 
-                                <li class="social-icon-item"><a class="social-icon-link bi-linkedin" target="blank"
+                                <li class="social-icon-item"><a class="social-icon-link bi-linkedin" target="blank" aria-label="linkedin"
                                         href="https://www.linkedin.com/in/yesimhozman"></a> </li>
 
-                                <li class="social-icon-item"><a href="https://www.github.com/yesimhozman" target="blank"
+                                <li class="social-icon-item"><a href="https://www.github.com/yesimhozman" target="blank" aria-label="github"
                                         class="social-icon-link bi-github"></a></li>
 
                             </ul>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/79595465/197255359-705d7a30-d43c-46da-9e8c-92288a19c63a.png)
In the lighthouse, there is a suggestion to add aria-labels in "a"tags. After the changes, my accessibility score is 100. 